### PR TITLE
Handle connection errors when web-hook is fired.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -21,8 +21,11 @@ function fire(url, secret, payload) {
     req = req.set('x-hub-signature', signature)
   }
   req.send(body)
-  req.end(function (req) {
-    if (req.status >= 300 || req.status < 100) {
+  req.end(function (err, req){
+    if(err){
+      console.error('failed to fire webhook', err);
+    }
+    else if (req.status >= 300 || req.status < 100) {
       console.error('failed to fire webhook', req.status, req.text, url, secret, payload)
     }
   })
@@ -36,7 +39,7 @@ var DEFAULT_FORMAT = {
   repo_url: 'job.project.provider.config.url',
   // results
   test_exitcode: 'data.exitCode',
-  finish_time: 'data.time',
+  finish_time: 'data.time'
 }
 
 function crawlTree(obj, fn) {


### PR DESCRIPTION
because `req.end` was being passed a callback with only one argument any request error would throw. I declared the argument `err` and log it if exists.
