### PR TITLE
fix #4: add webhooks works

### DIFF
--- a/config/config.html
+++ b/config/config.html
@@ -25,9 +25,9 @@
             <th>Shared secret for HMAC-SHA1 signature</th>
           </thead>
           <tbody>
-            <tr ng-repeat-start="hook in hooks">
+            <tr ng-repeat-start="hook in hooks track by $index">
               <td><input ng-model="hook.title"></td>
-              <td><input ng-model="hook.url"</td>
+              <td><input ng-model="hook.url"></td>
               <td><input ng-model="hook.secret"></td>
               <td class="remove">
                 <button class="btn btn-danger" ng-disabled="saving" ng-click="remove(hook)">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strider-webhooks",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Enables strider to fire webhooks based on certain events",
   "main": "webapp.js",
   "scripts": {


### PR DESCRIPTION
This pull request fixes #4 and users can add webhooks again. 

**Problem**
Angular adds a `$$hashkey` property to the object used in `ng-repeat` loops to distinct and recognize changes on them. The object containing the new webhook information also contained the `$$hashkey` property while it was sent to the server. On server side, MongoDB doesn’t allow saving properties beginning with the `$` symbol.

**Fix**
Add `track by $index` to the Angular `ng-repeat` loop to avoid the creation of the `$$hashkey` object.

Additionally, I added a missing closing tag for the url input.