### PR TITLE
Fixed custom payload

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,7 +64,11 @@ function getHookValue(data, job, key) {
 }
 
 function makeHook(format, job) {
-  format = format || DEFAULT_FORMAT
+  try {
+    format = JSON.parse(format)
+  } catch(err) {
+    format = DEFAULT_FORMAT
+  }
   return function (data, job) {
     return crawlTree(format, getHookValue.bind(null, data, job))
   }


### PR DESCRIPTION
Variable `format` In function `makeHook` was string, and it was impossible to pass any custom parameter in payload.